### PR TITLE
Fix pod readiness check

### DIFF
--- a/tasks/change_config.yml
+++ b/tasks/change_config.yml
@@ -29,8 +29,7 @@
   failed_when: "all_pods_ready.rc != 0"
   changed_when: false
   register: all_pods_ready
-  until:
-    '"0" in all_pods_ready.stdout'
+  until: "all_pods_ready.stdout == '0'"
   retries: 100
   delay: 15
   delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -61,8 +61,7 @@
   failed_when: "all_pods_ready.rc != 0"
   changed_when: false
   register: all_pods_ready
-  until:
-    '"0" in all_pods_ready.stdout'
+  until: "all_pods_ready.stdout == '0'"
   retries: 100
   delay: 15
   delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"


### PR DESCRIPTION
# Description
Pod readiness check was expecting a 0 in the output, which means if the output is 10 or 20, the check returns a false positive, now its changed so that the check expects a 0 exactly, not 0 as part of the output.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)
