### PR TITLE
Add checking of container state and RabbitMQ replication

### DIFF
--- a/files/check_containers.py
+++ b/files/check_containers.py
@@ -1,0 +1,47 @@
+from argparse import ArgumentParser
+from kubernetes import client, config  # noqa: E402
+
+arguments = ArgumentParser()
+arguments.add_argument(
+    "--kubeconfig",
+    dest="kubeconfig",
+    type=str,
+    help="Path to the kubeconfig file to use",
+    required=True,
+)
+arguments = arguments.parse_args()
+
+
+def get_containers_not_ready(kubeconfig: str) -> list | None:
+    config.load_kube_config(kubeconfig)
+    v1_client = client.CoreV1Api()
+    pods = v1_client.list_pod_for_all_namespaces()
+    non_ready_cont = []
+
+    for pod in pods.items:
+        for container in pod.status.container_statuses:
+            if not container.ready:
+                if (container.state.terminated and container.state.terminated.exit_code == 0):
+                    continue
+                else:
+                    container_list_object = {
+                        'name': f"{container.name}",
+                        'pod_name': f"{pod.metadata.name}"
+                    }
+                    non_ready_cont.append(container_list_object)
+
+    if non_ready_cont:
+        return non_ready_cont
+    else:
+        return None
+
+
+not_ready_containers = get_containers_not_ready(kubeconfig=arguments.kubeconfig)
+
+if not_ready_containers:
+    print("Some containers not reporting ready status:")
+    for cont in not_ready_containers:
+        print(f'Container [{cont["name"]}] in pod [{cont["pod_name"]}] not ready or terminated with 0')
+    exit(1)
+else:
+    exit(0)

--- a/files/check_rabbitmq_replication.py
+++ b/files/check_rabbitmq_replication.py
@@ -1,0 +1,89 @@
+from argparse import ArgumentParser
+from subprocess import Popen, PIPE
+from time import sleep
+from psutil import net_connections
+from random import randrange
+from requests.auth import HTTPBasicAuth
+from kubernetes import client, config  # noqa: E402
+import requests
+import base64
+
+arguments = ArgumentParser()
+arguments.add_argument('--kubectl_path', dest='kubectl_path', type=str, help='kubectl binary path', required=True)
+arguments.add_argument('--kubeconfig', dest='kubeconfig', type=str, help='Path to the kubeconfig file to use', required=True)
+arguments.add_argument('--namespace', dest='namespace', type=str, help='RabbitMQ namespace', default='infra')
+arguments.add_argument('--rabbitmq_secret_name', dest='rabbitmq_secret_name', type=str, help='RabbitMQ default user secret name', default='rabbitmq-cluster-default-user')
+arguments.add_argument('--rabbitmq_service_name', dest='rabbitmq_service_name', type=str, help='RabbitMQ Service name', default='services/rabbitmq-cluster')
+arguments = arguments.parse_args()
+
+def check_rabbitmq_queue_repl(rabbitmq_url :str, username :str, password :str, rabbimq_repl_nodes :int = 3) -> list | None:
+  '''
+  Check all quorum queues, and return those that are not fully replicated (replicated on less nodes than expected)
+
+  :param rabbitmq_url: RabbitMQ management API URL
+  :param rabbimq_repl_nodes: Number of RabbitMQ nodes that should have the queue replicated
+  :param username: RabbitMQ management API username
+  :param password: RabbitMQ management API password
+
+  :return list: List of queues that are not fully replicated
+  '''
+
+  failed_queues = []
+  url = f'{rabbitmq_url}/api/queues'
+  response = requests.get(url, auth=HTTPBasicAuth(username,password))
+
+  for queue in response.json():
+    if queue['type'] == "quorum":
+      if len(queue['online']) != rabbimq_repl_nodes:
+        failed_queues.append(queue)
+
+  if failed_queues:
+    return failed_queues
+  else:
+    return None
+
+# Get credentials
+config.load_kube_config(f"{arguments.kubeconfig}")
+v1_client = client.CoreV1Api()
+
+try:
+    # Get the secret
+    secret = v1_client.read_namespaced_secret(name=f"{arguments.rabbitmq_secret_name}", namespace=f"{arguments.namespace}")
+
+    username = base64.b64decode(secret.data['username']).decode('utf-8')
+    password = base64.b64decode(secret.data['password']).decode('utf-8')
+
+except client.exceptions.ApiException as exception:
+    print(f"Error fetching secret: {exception}")
+
+# Open port-forward
+used_listening_ports = []
+
+for conn in net_connections(kind='inet'):
+  if conn.status == 'LISTEN':
+    used_listening_ports.append(conn.laddr.port) # type: ignore
+
+random_pf_port = randrange(32770,65500)
+
+while random_pf_port in used_listening_ports:
+  random_pf_port = randrange(32770,65500)
+
+command = [f"{arguments.kubectl_path}", "port-forward", f"{arguments.rabbitmq_service_name}", f"{random_pf_port}:management", "--namespace", f"{arguments.namespace}", "--kubeconfig", f"{arguments.kubeconfig}"]
+process = Popen(command, stdout=PIPE, stderr=PIPE)
+
+sleep(5)
+
+try:
+  failed_queues = check_rabbitmq_queue_repl(rabbitmq_url=f"http://localhost:{random_pf_port}", username=username, password=password)
+
+finally:
+  process.terminate()
+  process.wait()
+
+if not failed_queues:
+  exit(0)
+else:
+  print("CRITICAL: Quorum queues not in sync")
+  for queue in failed_queues:
+    print(f"FAIL - Queue [{queue['name']}] has {len(queue['online'])} nodes online")
+  exit(1)

--- a/tasks/change_config.yml
+++ b/tasks/change_config.yml
@@ -161,3 +161,58 @@
   delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
   run_once: true
   when: inventory_hostname in groups[rke2_agents_group_name]
+
+- block:
+    - name: Ensure pip and venv is installed
+      ansible.builtin.apt:
+        name: "{{ item }}"
+        state: present
+        update_cache: yes
+        cache_valid_time: 3600
+      loop:
+        - python3-pip
+        - python3-venv
+
+    - name: Ensure the virtual environment exists
+      ansible.builtin.pip:
+        name: "{{ venv_modules }}"
+        virtualenv: "{{ venv_dir }}"
+        virtualenv_command: "python3 -m venv"
+
+    - name: Wait for all containers to be ready
+      ansible.builtin.script: files/check_containers.py --kubeconfig /etc/rancher/rke2/rke2.yaml
+      args:
+        executable: "{{ venv_python }}"
+      register: all_containers_ready
+      failed_when: all_containers_ready.stdout.strip() != ""
+      changed_when: false
+      until: all_containers_ready.stdout.strip() == ""
+      retries: 120
+      delay: 15
+      when: 
+        - patch_k8s_wait_for_all_pods_to_be_ready is defined 
+        - patch_k8s_wait_for_all_pods_to_be_ready | bool
+
+    - name: Wait for all RabbitMQ queues to be replicated
+      ansible.builtin.script: files/check_rabbitmq_replication.py --kubectl_path {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml --namespace {{ k8s_patch_rabbitmq_namespace }}
+      args:
+        executable: "{{ venv_python }}"
+      register: all_rabbitmq_queues_replicated
+      failed_when: all_rabbitmq_queues_replicated.stdout.strip() != ""
+      changed_when: false
+      until: all_rabbitmq_queues_replicated.stdout.strip() == ""
+      retries: 120
+      delay: 15
+      when: inventory_hostname in groups[rke2_agents_group_name]
+  vars:
+    venv_modules:
+      - kubernetes==29.0.0
+      - psutil==6.0.0
+      - requests
+    venv_dir: /tmp/k8s_post_patch_venv
+    venv_python: "{{ venv_dir }}/bin/python3"
+  always:
+    - name: Ensure the virtual environment is deleted
+      ansible.builtin.file:
+        path: "{{ venv_dir }}"
+        state: absent

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -240,6 +240,7 @@
       - requests
     venv_dir: /tmp/k8s_post_patch_venv
     venv_python: "{{ venv_dir }}/bin/python3"
+  delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
   always:
     - name: Ensure the virtual environment is deleted
       ansible.builtin.file:

--- a/tasks/rolling_restart.yml
+++ b/tasks/rolling_restart.yml
@@ -190,3 +190,58 @@
   delegate_to: "{{ active_server | default(groups[rke2_servers_group_name].0) }}"
   run_once: true
   when: inventory_hostname in groups[rke2_agents_group_name]
+
+- block:
+    - name: Ensure pip and venv is installed
+      ansible.builtin.apt:
+        name: "{{ item }}"
+        state: present
+        update_cache: yes
+        cache_valid_time: 3600
+      loop:
+        - python3-pip
+        - python3-venv
+
+    - name: Ensure the virtual environment exists
+      ansible.builtin.pip:
+        name: "{{ venv_modules }}"
+        virtualenv: "{{ venv_dir }}"
+        virtualenv_command: "python3 -m venv"
+
+    - name: Wait for all containers to be ready
+      ansible.builtin.script: files/check_containers.py --kubeconfig /etc/rancher/rke2/rke2.yaml
+      args:
+        executable: "{{ venv_python }}"
+      register: all_containers_ready
+      failed_when: all_containers_ready.stdout.strip() != ""
+      changed_when: false
+      until: all_containers_ready.stdout.strip() == ""
+      retries: 120
+      delay: 15
+      when: 
+        - patch_k8s_wait_for_all_pods_to_be_ready is defined 
+        - patch_k8s_wait_for_all_pods_to_be_ready | bool
+
+    - name: Wait for all RabbitMQ queues to be replicated
+      ansible.builtin.script: files/check_rabbitmq_replication.py --kubectl_path {{ rke2_data_path }}/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml --namespace {{ k8s_patch_rabbitmq_namespace }}
+      args:
+        executable: "{{ venv_python }}"
+      register: all_rabbitmq_queues_replicated
+      failed_when: all_rabbitmq_queues_replicated.stdout.strip() != ""
+      changed_when: false
+      until: all_rabbitmq_queues_replicated.stdout.strip() == ""
+      retries: 120
+      delay: 15
+      when: inventory_hostname in groups[rke2_agents_group_name]
+  vars:
+    venv_modules:
+      - kubernetes==29.0.0
+      - psutil==6.0.0
+      - requests
+    venv_dir: /tmp/k8s_post_patch_venv
+    venv_python: "{{ venv_dir }}/bin/python3"
+  always:
+    - name: Ensure the virtual environment is deleted
+      ansible.builtin.file:
+        path: "{{ venv_dir }}"
+        state: absent


### PR DESCRIPTION
# Description
Add checking of container state and RabbitMQ replication when restarting RKE2

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Small minor change not affecting the Ansible Role code (GitHub Actions Workflow, Documentation etc.)
